### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ class Autod extends EventEmitter {
 
     // support plugin parse file
     if (this.options.plugin) {
-      const pluginModules = this.options.plugin(filePath, file) || [];
+      const pluginModules = this.options.plugin(filePath, file, modules) || [];
       pluginModules.forEach(name => {
         modules.push(name);
         this.dependencyMap[name] = this.dependencyMap[name] || [];


### PR DESCRIPTION
支持在 plugin 中可以访问解析完成的 modules

原由： 目前的插件机制，只支持新增 依赖，不支持忽略特定的依赖